### PR TITLE
La til en pipeline feature som fjerner subdomains for gitte hosts fra Origin header.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions.jvmTarget = "11"
+    kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
 }
 
 application {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
     maven("https://jitpack.io")
 }
 
-val dittNavDependenciesVersion = "2020.10.05-09.03-c152824aa61a"
+val dittNavDependenciesVersion = "2020.10.15-14.44-9a9fec08d58f"
 
 dependencies {
     implementation("com.github.navikt:dittnav-dependencies:$dittNavDependenciesVersion")

--- a/src/main/kotlin/no/nav/personbruker/innloggingsstatus/config/MaskOriginSubDomain.kt
+++ b/src/main/kotlin/no/nav/personbruker/innloggingsstatus/config/MaskOriginSubDomain.kt
@@ -1,0 +1,82 @@
+package no.nav.personbruker.innloggingsstatus.config
+
+import io.ktor.application.*
+import io.ktor.http.HttpHeaders.Origin
+import io.ktor.request.*
+import io.ktor.server.netty.*
+import io.ktor.util.*
+import io.ktor.util.pipeline.*
+import io.netty.handler.codec.http.DefaultHttpHeaders
+import io.netty.handler.codec.http.HttpHeaders
+
+class MaskOriginSubDomain(config: Config) {
+
+    private val originPatterns = config.originPatterns
+
+    @OptIn(InternalAPI::class)
+    fun intercept(context: PipelineContext<Unit, ApplicationCall>) {
+
+        val request = context.call.request
+
+        if (request.headers !is NettyApplicationRequestHeaders) {
+            return
+        }
+
+        val origin = request.headers.getAll(Origin)?.singleOrNull()
+
+        if (origin != null) {
+            removeOriginSubDomain(request, origin)
+        }
+
+    }
+
+    @OptIn(InternalAPI::class)
+    private val ApplicationRequest.mutableHeaders: HttpHeaders get() {
+        // Use reflection to access private field 'headers' contained in instance of NettyApplicationRequestHeaders
+        return NettyApplicationRequestHeaders::class.java.getDeclaredField("headers").let {
+            it.isAccessible = true
+            val backingField = it.get((headers)) as DefaultHttpHeaders
+            it.isAccessible = false
+            backingField
+        }
+    }
+
+    private fun removeOriginSubDomain(request: ApplicationRequest, origin: String) {
+        val headers = request.mutableHeaders
+
+        for (pattern in originPatterns) {
+            pattern.find(origin)?.destructured?.let { (schema, host) ->
+                headers[Origin] = "$schema://$host"
+            }
+        }
+    }
+
+    class Config {
+        val originPatterns = mutableSetOf<Regex>()
+
+        fun host(host: String, schemes: List<String> = listOf("http")) {
+            if (host == "*") {
+                return
+            }
+
+            require("://" !in host) { "Schema skal ikke inkluderes i host-strengen direkte." }
+
+            for (schema in schemes) {
+                val hostPattern = host.replace(".", "\\.")
+
+                originPatterns.add("^($schema)://.*\\.($hostPattern.*)\$".toRegex())
+            }
+        }
+    }
+
+    companion object Feature : ApplicationFeature<ApplicationCallPipeline, Config, MaskOriginSubDomain> {
+
+        override val key: AttributeKey<MaskOriginSubDomain> = AttributeKey("MaskOriginSubDomain")
+
+        override fun install(pipeline: ApplicationCallPipeline, configure: Config.() -> Unit): MaskOriginSubDomain {
+            val maskOriginSubDomain = MaskOriginSubDomain(Config().apply(configure))
+            pipeline.intercept(ApplicationCallPipeline.Features) { maskOriginSubDomain.intercept(this) }
+            return maskOriginSubDomain
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/innloggingsstatus/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/innloggingsstatus/config/bootstrap.kt
@@ -26,6 +26,13 @@ fun Application.mainModule() {
 
     val environment = applicationContext.environment
 
+    install(MaskOriginSubDomain) {
+        host(
+            host = environment.corsAllowedOrigins,
+            schemes = environment.corsAllowedSchemes
+        )
+    }
+
     install(CORS) {
         host(
             host = environment.corsAllowedOrigins,

--- a/src/main/kotlin/no/nav/personbruker/innloggingsstatus/openam/EssoTokenRetriever.kt
+++ b/src/main/kotlin/no/nav/personbruker/innloggingsstatus/openam/EssoTokenRetriever.kt
@@ -1,9 +1,0 @@
-package no.nav.personbruker.innloggingsstatus.openam
-
-import io.ktor.application.ApplicationCall
-
-object EssoTokenRetriever {
-    const val NAV_ESSO_COOKIE = "nav-esso"
-
-
-}

--- a/src/test/kotlin/no/nav/personbruker/innloggingsstatus/auth/AuthTokenServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/innloggingsstatus/auth/AuthTokenServiceTest.kt
@@ -11,7 +11,7 @@ import no.nav.personbruker.innloggingsstatus.oidc.OidcTokenService
 import no.nav.personbruker.innloggingsstatus.openam.OpenAMTokenInfo
 import no.nav.personbruker.innloggingsstatus.openam.OpenAMTokenService
 import no.nav.personbruker.innloggingsstatus.user.SubjectNameService
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
@@ -49,9 +49,9 @@ internal class AuthTokenServiceTest {
 
         val subjectInfo = runBlocking { authTokenService.getAuthenticatedUserInfo(call) }
 
-        subjectInfo.authenticated `should equal` true
-        subjectInfo.name `should equal` subject1Name
-        subjectInfo.securityLevel `should equal` "3"
+        subjectInfo.authenticated `should be equal to` true
+        subjectInfo.name `should be equal to` subject1Name
+        subjectInfo.securityLevel `should be equal to` "3"
     }
 
     @Test
@@ -68,9 +68,9 @@ internal class AuthTokenServiceTest {
 
         val subjectInfo = runBlocking { authTokenService.getAuthenticatedUserInfo(call) }
 
-        subjectInfo.authenticated `should equal` true
-        subjectInfo.name `should equal` subject1Name
-        subjectInfo.securityLevel `should equal` "3"
+        subjectInfo.authenticated `should be equal to` true
+        subjectInfo.name `should be equal to` subject1Name
+        subjectInfo.securityLevel `should be equal to` "3"
     }
 
     @Test
@@ -82,9 +82,9 @@ internal class AuthTokenServiceTest {
 
         val subjectInfo = runBlocking { authTokenService.getAuthenticatedUserInfo(call) }
 
-        subjectInfo.authenticated `should equal` false
-        subjectInfo.name `should equal` null
-        subjectInfo.securityLevel `should equal` null
+        subjectInfo.authenticated `should be equal to` false
+        subjectInfo.name `should be equal to` null
+        subjectInfo.securityLevel `should be equal to` null
     }
 
     @Test
@@ -109,9 +109,9 @@ internal class AuthTokenServiceTest {
 
         val subjectInfo = runBlocking { authTokenService.getAuthenticatedUserInfo(call) }
 
-        subjectInfo.authenticated `should equal` true
-        subjectInfo.name `should equal` subject1Name
-        subjectInfo.securityLevel `should equal` "4"
+        subjectInfo.authenticated `should be equal to` true
+        subjectInfo.name `should be equal to` subject1Name
+        subjectInfo.securityLevel `should be equal to` "4"
     }
 
     @Test
@@ -136,9 +136,9 @@ internal class AuthTokenServiceTest {
 
         val subjectInfo = runBlocking { authTokenService.getAuthenticatedUserInfo(call) }
 
-        subjectInfo.authenticated `should equal` true
-        subjectInfo.name `should equal` subject1Name
-        subjectInfo.securityLevel `should equal` "4"
+        subjectInfo.authenticated `should be equal to` true
+        subjectInfo.name `should be equal to` subject1Name
+        subjectInfo.securityLevel `should be equal to` "4"
     }
 
     @Test
@@ -163,9 +163,9 @@ internal class AuthTokenServiceTest {
 
         val subjectInfo = runBlocking { authTokenService.getAuthenticatedUserInfo(call) }
 
-        subjectInfo.authenticated `should equal` false
-        subjectInfo.name `should equal` null
-        subjectInfo.securityLevel `should equal` null
+        subjectInfo.authenticated `should be equal to` false
+        subjectInfo.name `should be equal to` null
+        subjectInfo.securityLevel `should be equal to` null
     }
 
     @Test
@@ -182,9 +182,9 @@ internal class AuthTokenServiceTest {
 
         val subjectInfo = runBlocking { authTokenService.getAuthenticatedUserInfo(call) }
 
-        subjectInfo.authenticated `should equal` false
-        subjectInfo.name `should equal` null
-        subjectInfo.securityLevel `should equal` null
+        subjectInfo.authenticated `should be equal to` false
+        subjectInfo.name `should be equal to` null
+        subjectInfo.securityLevel `should be equal to` null
     }
 
     @Test
@@ -203,9 +203,9 @@ internal class AuthTokenServiceTest {
 
         val subjectInfo = runBlocking { authTokenService.getAuthenticatedUserInfo(call) }
 
-        subjectInfo.authenticated `should equal` false
-        subjectInfo.name `should equal` null
-        subjectInfo.securityLevel `should equal` null
+        subjectInfo.authenticated `should be equal to` false
+        subjectInfo.name `should be equal to` null
+        subjectInfo.securityLevel `should be equal to` null
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/innloggingsstatus/oidc/OidcTokenServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/innloggingsstatus/oidc/OidcTokenServiceTest.kt
@@ -5,7 +5,7 @@ import io.ktor.util.KtorExperimentalAPI
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.personbruker.innloggingsstatus.config.Environment
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should throw`
 import org.amshove.kluent.invoking
 import org.junit.jupiter.api.Test
@@ -37,10 +37,10 @@ internal class OidcTokenServiceTest {
 
         val oidcTokenInfo = oidcTokenService.getOidcToken(call)
 
-        oidcTokenInfo?.subject `should equal` subject
-        oidcTokenInfo?.authLevel `should equal` level
-        oidcTokenInfo?.issueTime?.toEpochSecond(ZoneOffset.UTC) `should equal` issueTime.toEpochSecond(ZoneOffset.UTC)
-        oidcTokenInfo?.expiryTime?.toEpochSecond(ZoneOffset.UTC) `should equal` expiryTime.toEpochSecond(ZoneOffset.UTC)
+        oidcTokenInfo?.subject `should be equal to` subject
+        oidcTokenInfo?.authLevel `should be equal to` level
+        oidcTokenInfo?.issueTime?.toEpochSecond(ZoneOffset.UTC) `should be equal to` issueTime.toEpochSecond(ZoneOffset.UTC)
+        oidcTokenInfo?.expiryTime?.toEpochSecond(ZoneOffset.UTC) `should be equal to` expiryTime.toEpochSecond(ZoneOffset.UTC)
     }
 
     @Test
@@ -57,10 +57,10 @@ internal class OidcTokenServiceTest {
 
         val oidcTokenInfo = oidcTokenService.getOidcToken(call)
 
-        oidcTokenInfo?.subject `should equal` subject
-        oidcTokenInfo?.authLevel `should equal` level
-        oidcTokenInfo?.issueTime?.toEpochSecond(ZoneOffset.UTC) `should equal` issueTime.toEpochSecond(ZoneOffset.UTC)
-        oidcTokenInfo?.expiryTime?.toEpochSecond(ZoneOffset.UTC) `should equal` expiryTime.toEpochSecond(ZoneOffset.UTC)
+        oidcTokenInfo?.subject `should be equal to` subject
+        oidcTokenInfo?.authLevel `should be equal to` level
+        oidcTokenInfo?.issueTime?.toEpochSecond(ZoneOffset.UTC) `should be equal to` issueTime.toEpochSecond(ZoneOffset.UTC)
+        oidcTokenInfo?.expiryTime?.toEpochSecond(ZoneOffset.UTC) `should be equal to` expiryTime.toEpochSecond(ZoneOffset.UTC)
     }
 
 

--- a/src/test/kotlin/no/nav/personbruker/innloggingsstatus/openam/OpenAMTokenInfoProviderTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/innloggingsstatus/openam/OpenAMTokenInfoProviderTest.kt
@@ -3,7 +3,7 @@ package no.nav.personbruker.innloggingsstatus.openam
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.innloggingsstatus.cache.MockedEvictingCacheFactory
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
@@ -32,8 +32,8 @@ internal class OpenAMTokenInfoProviderTest {
 
         val result = runBlocking { nonCachingProvider.getTokenInfo(essoToken) }
 
-        result?.subject `should equal` subject
-        result?.authLevel `should equal` authLevel
+        result?.subject `should be equal to` subject
+        result?.authLevel `should be equal to` authLevel
     }
 
     @Test
@@ -43,8 +43,8 @@ internal class OpenAMTokenInfoProviderTest {
 
         val result = runBlocking { cachingProvider.getTokenInfo(essoToken) }
 
-        result?.subject `should equal` subject
-        result?.authLevel `should equal` authLevel
+        result?.subject `should be equal to` subject
+        result?.authLevel `should be equal to` authLevel
 
         coVerifyOrder {
             shallowCache.getEntry(essoToken, any())
@@ -58,7 +58,7 @@ internal class OpenAMTokenInfoProviderTest {
 
         val result = runBlocking { nonCachingProvider.getTokenInfo(essoToken) }
 
-        result `should equal` null
+        result `should be equal to` null
     }
 
     @Test
@@ -67,7 +67,7 @@ internal class OpenAMTokenInfoProviderTest {
 
         val result = runBlocking { cachingProvider.getTokenInfo(essoToken) }
 
-        result `should equal` null
+        result `should be equal to` null
 
         coVerifyOrder {
             shallowCache.getEntry(essoToken, any())

--- a/src/test/kotlin/no/nav/personbruker/innloggingsstatus/openam/OpenAMTokenServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/innloggingsstatus/openam/OpenAMTokenServiceTest.kt
@@ -3,7 +3,7 @@ package no.nav.personbruker.innloggingsstatus.openam
 import io.ktor.application.ApplicationCall
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
@@ -30,7 +30,7 @@ internal class OpenAMTokenServiceTest {
 
         val response = runBlocking { openAMTokenService.getOpenAMToken(call) }
 
-        response `should equal` null
+        response `should be equal to` null
 
         coVerify(exactly = 0) { tokenProvider.getTokenInfo(any()) }
     }
@@ -42,7 +42,7 @@ internal class OpenAMTokenServiceTest {
 
         val response = runBlocking { openAMTokenService.getOpenAMToken(call) }
 
-        response?.authLevel `should equal` authLevel
-        response?.subject `should equal` subject
+        response?.authLevel `should be equal to` authLevel
+        response?.subject `should be equal to` subject
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/innloggingsstatus/pdl/PdlServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/innloggingsstatus/pdl/PdlServiceTest.kt
@@ -6,7 +6,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.innloggingsstatus.sts.STSException
 import no.nav.personbruker.innloggingsstatus.sts.StsService
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 
 internal class PdlServiceTest {
@@ -29,7 +29,7 @@ internal class PdlServiceTest {
 
         val response = runBlocking { pdlService.getSubjectName(ident) }
 
-        response `should equal` null
+        response `should be equal to` null
     }
 
     @Test
@@ -40,7 +40,7 @@ internal class PdlServiceTest {
 
         val response = runBlocking { pdlService.getSubjectName(ident) }
 
-        response `should equal` null
+        response `should be equal to` null
         coVerify(exactly = 1) { stsService.invalidateToken() }
     }
 
@@ -51,7 +51,7 @@ internal class PdlServiceTest {
 
         val response = runBlocking { pdlService.getSubjectName(ident) }
 
-        response `should equal` null
+        response `should be equal to` null
         coVerify(exactly = 0) { stsService.invalidateToken() }
     }
 
@@ -64,8 +64,8 @@ internal class PdlServiceTest {
 
         val response = runBlocking { pdlService.getSubjectName(ident) }
 
-        response?.fornavn `should equal` fornavn
-        response?.mellomnavn `should equal` mellomnavn
-        response?.etternavn `should equal` etternavn
+        response?.fornavn `should be equal to` fornavn
+        response?.mellomnavn `should be equal to` mellomnavn
+        response?.etternavn `should be equal to` etternavn
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/innloggingsstatus/user/SubjectNameServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/innloggingsstatus/user/SubjectNameServiceTest.kt
@@ -7,7 +7,7 @@ import no.nav.personbruker.dittnav.common.util.cache.EvictingCache
 import no.nav.personbruker.innloggingsstatus.cache.MockedEvictingCacheFactory
 import no.nav.personbruker.innloggingsstatus.pdl.PdlService
 import no.nav.personbruker.innloggingsstatus.pdl.query.PdlNavn
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 
 internal class SubjectNameServiceTest {
@@ -29,7 +29,7 @@ internal class SubjectNameServiceTest {
 
         val result = runBlocking { subjectNameService.getSubjectName(subject) }
 
-        result `should equal` subject
+        result `should be equal to` subject
     }
 
     @Test
@@ -40,7 +40,7 @@ internal class SubjectNameServiceTest {
 
         val result = runBlocking { subjectNameService.getSubjectName(subject) }
 
-        result `should equal` "$fornavn $mellomnavn $etternavn"
+        result `should be equal to` "$fornavn $mellomnavn $etternavn"
     }
 
     @Test
@@ -51,7 +51,7 @@ internal class SubjectNameServiceTest {
 
         val result = runBlocking { subjectNameService.getSubjectName(subject) }
 
-        result `should equal` "$fornavn $etternavn"
+        result `should be equal to` "$fornavn $etternavn"
     }
 
     @Test
@@ -62,7 +62,7 @@ internal class SubjectNameServiceTest {
 
         val result = runBlocking { subjectNameService.getSubjectName(subject) }
 
-        result `should equal` "$fornavn $etternavn"
+        result `should be equal to` "$fornavn $etternavn"
     }
 
 }


### PR DESCRIPTION
Filteret sjekker om verdien i Origin header matcher gitte kombinasjoner av schemes og hosts.

Dersom vi får en match, bruker filteret reflection til å hente et privat HttpHeader felt som er mutable, og overskriver Origin til samme url, men uten subdomain. Dette gjør at CORS filteret som kjøres senere ikke trenger å forholde seg til subdomain.  