### PR TITLE
Hever requests-cpu for å tilpasse reell trafikk.

### DIFF
--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -39,7 +39,7 @@ spec:
       cpu: "3"
       memory: 1536Mi
     requests:
-      cpu: "50m"
+      cpu: "100m"
       memory: 384Mi
   azure:
     application:


### PR DESCRIPTION
For lav requests-verdi førte til at det ofte var max antall podder. Hever requests etter reell bruk.