### PR TITLE
Ktor3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 plugins {
-    val kotlinVersion = "2.0.21"
+    val kotlinVersion = "2.1.0"
     val shadowVersion = "8.1.1"
     val versionsVersion = "0.51.0"
 
@@ -31,18 +31,18 @@ repositories {
 dependencies {
     val caffeineVersion = "3.1.8"
     val dittnavCommonVersion = "2022.09.30-12.41-aa46d2d75788"
-    val tmsKtorTokenSupportVersion = "4.1.1"
-    val jacksonVersion = "2.18.1"
+    val jacksonVersion = "2.18.2"
     val junitVersion = "5.11.3"
+    val kotestVersion = "5.9.1"
     val kotlinxCoroutinesVersion = "1.9.0"
     val kotlinxHtmlJvmVersion = "0.11.0"
-    val ktorVersion = "2.3.12"
+    val ktorVersion = "3.0.1"
     val logbackVersion = "1.5.12"
     val logstashVersion = "8.0"
     val micrometerVersion = "1.14.1"
     val mockkVersion = "1.13.13"
-    val navSecurityVersion = "5.0.11"
-    val kotestVersion = "5.9.1"
+    val navSecurityVersion = "5.0.13"
+    val tmsKtorTokenSupportVersion = "5.0.0"
 
     implementation("com.github.navikt.dittnav-common-lib:dittnav-common-utils:$dittnavCommonVersion")
     implementation("no.nav.tms.token.support:azure-exchange:$tmsKtorTokenSupportVersion")
@@ -68,7 +68,7 @@ dependencies {
     implementation("io.micrometer:micrometer-registry-prometheus:$micrometerVersion")
     implementation("ch.qos.logback:logback-classic:$logbackVersion")
     implementation("net.logstash.logback:logstash-logback-encoder:$logstashVersion")
-    implementation("no.nav.security:token-validation-ktor-v2:$navSecurityVersion")
+    implementation("no.nav.security:token-validation-ktor-v3:$navSecurityVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
     testImplementation("io.ktor:ktor-client-mock:$ktorVersion")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/no/nav/dekoratoren/api/innloggingsstatus/oidc/OidcTokenValidator.kt
+++ b/src/main/kotlin/no/nav/dekoratoren/api/innloggingsstatus/oidc/OidcTokenValidator.kt
@@ -2,12 +2,15 @@ package no.nav.dekoratoren.api.innloggingsstatus.oidc
 
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.config.ApplicationConfig
+import no.nav.security.token.support.core.JwtTokenConstants.AUTHORIZATION_HEADER
 import no.nav.security.token.support.core.configuration.IssuerProperties
+import no.nav.security.token.support.core.configuration.IssuerProperties.JwksCache
+import no.nav.security.token.support.core.configuration.IssuerProperties.Validation
 import no.nav.security.token.support.core.configuration.MultiIssuerConfiguration
 import no.nav.security.token.support.core.configuration.ProxyAwareResourceRetriever
 import no.nav.security.token.support.core.jwt.JwtToken
 import no.nav.security.token.support.core.validation.JwtTokenValidationHandler
-import no.nav.security.token.support.v2.asIssuerProps
+import no.nav.security.token.support.v3.asIssuerProps
 
 class OidcTokenValidator(applicationConfig: ApplicationConfig) {
     private val resourceRetriever: ProxyAwareResourceRetriever = ProxyAwareResourceRetriever()

--- a/src/main/kotlin/no/nav/dekoratoren/api/varsel/VarselRoute.kt
+++ b/src/main/kotlin/no/nav/dekoratoren/api/varsel/VarselRoute.kt
@@ -11,9 +11,7 @@ import io.ktor.server.request.ApplicationRequest
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondBytes
-import io.ktor.server.routing.Route
-import io.ktor.server.routing.get
-import io.ktor.server.routing.post
+import io.ktor.server.routing.*
 import io.ktor.util.pipeline.PipelineContext
 import no.nav.dekoratoren.api.innloggingsstatus.oidc.OidcTokenService
 
@@ -77,7 +75,7 @@ fun Route.varsel(oidcTokenService: OidcTokenService, varselbjelleConsumer: Varse
     }
 }
 
-suspend fun PipelineContext<Unit, ApplicationCall>.doIfAuthenticated(
+suspend fun RoutingContext.doIfAuthenticated(
     oidcTokenService: OidcTokenService,
     block: suspend (String, Int) -> Unit
 ) {

--- a/src/test/kotlin/no/nav/dekoratoren/api/varsel/VarselApiTest.kt
+++ b/src/test/kotlin/no/nav/dekoratoren/api/varsel/VarselApiTest.kt
@@ -5,8 +5,7 @@ import io.kotest.matchers.shouldBe
 import io.ktor.client.request.header
 import io.ktor.client.request.request
 import io.ktor.client.request.url
-import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.*
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
@@ -17,7 +16,6 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
-import io.ktor.util.KtorDsl
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.every
@@ -61,7 +59,7 @@ class VarselApiTest {
         }
 
         result.status shouldBe HttpStatusCode.OK
-        result.readBytes() shouldBe sammendrag.encodeToByteArray()
+        result.readRawBytes() shouldBe sammendrag.encodeToByteArray()
     }
 
     @Test
@@ -78,7 +76,7 @@ class VarselApiTest {
         }
 
         result.status shouldBe HttpStatusCode.OK
-        result.readBytes() shouldBe id.encodeToByteArray()
+        result.readRawBytes() shouldBe id.encodeToByteArray()
     }
 
     @Test
@@ -179,7 +177,6 @@ class VarselApiTest {
 
     private fun unauthenticated() = null
 
-    @KtorDsl
     private fun testVarselApi(block: suspend ApplicationTestBuilder.(VarselbjelleConsumer) -> Unit) = testApplication {
         val varselbjelleConsumer = VarselbjelleConsumer(varselbjelleUrl, client, tokenFetcher)
 


### PR DESCRIPTION
En frivillig sjel lagde enn PR i token-support-biblioteket for å støtte Ktor 3 🎉
Dette er det som skal til: https://github.com/navikt/personopplysninger-api/commit/92082c23728c04978e9143a0737553a88024baa8

- Bump ktor-versjon til 3.0.1 og fiks skrivefeil i import av CallLogging
- Bump nav-security-versjon til 5.0.13 og bruk token-validation-ktor-v3 i stedet for v2
- Bump tms-ktor-token-support til 5.0.0